### PR TITLE
add front and not-front body classes

### DIFF
--- a/templates/html.html.twig
+++ b/templates/html.html.twig
@@ -48,15 +48,11 @@
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
   </head>
-  {% set classes = [] %}
+  {% set classes = [is_front ? 'front', not is_front ? 'not-front'] %}
   {% for role in user.roles %}
     {% set classes = classes|merge(['role--' ~ role|clean_class]) %}
   {% endfor %}
-
-  <body{{ attributes.addClass(classes,
-  not is_front ? 'with-subnav',
-  node_type
-  ) }}>
+  <body{{ attributes.addClass(classes) }}>
     <div id="skip">
       <a href="#main-menu" class="visually-hidden focusable skip-link">
         {{ 'Skip to main navigation'|t }}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding `front` and `not-front` classes dynamically to the body

# Needed By (Date)
- N/A

# Urgency
- No

# Steps to Test

1. Pull this branch
2. Verify that the homepage gets the `front` class and that non-front pages get the `not-front` class

# Affected Projects or Products
- stanford_basic

# Associated Issues and/or People
- N/A

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)