### PR TITLE
EARTH-449: Add additional class information to multiple value paragraph fields

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -62,8 +62,8 @@ function stanford_basic_preprocess_field(&$variables, $hook) {
   $variables['attributes']['class'][] = Html::cleanCssIdentifier($variables['field_type']);
   $variables['attributes']['class'][] = Html::cleanCssIdentifier('label-' . $variables['label_display']);
   
-  $first_item = $variables['element'][0] ?? NULL;
-  $is_paragraph = $first_item['#paragraph'] ?? FALSE;
+  $first_item = isset($variables['element'][0]) ? $variables['element'][0] : NULL;
+  $is_paragraph = isset($first_item['#paragraph']) ? $first_item['#paragraph'] : FALSE;
   $has_items = isset($variables['items']) ? count($variables['items']) : FALSE;
 
   // Add additional information to paragraph fields.
@@ -71,6 +71,9 @@ function stanford_basic_preprocess_field(&$variables, $hook) {
     foreach ($variables['items'] as &$pitem) {
       $paragraph_type = $pitem['content']['#paragraph']->getType();
       $ptype = Html::cleanCssIdentifier("ptype-" . $paragraph_type);
+      if (!isset($pitem['attributes']['class'])) {
+        $pitem['attributes']['class'] = [];
+      }
       $pitem['attributes']['class'][] = "paragraph-item";
       $pitem['attributes']['class'][] = $ptype;
     }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds additional css class information where before it was an empty div.

# Needed By (Date)
- Whenever

# Urgency
- None

# Steps to Test

1. Check out this branch
2. Clear caches
3. Review on the 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)