### PR TITLE
fixed preprocessing on paragraph field when using bricks

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -67,6 +67,8 @@ function stanford_basic_preprocess_field(&$variables, $hook) {
   $has_items = isset($variables['items']) ? count($variables['items']) : FALSE;
 
   // Add additional information to paragraph fields.
+  // Bricks has a different field type and structures the array differently, so
+  // we need to check if its actual normal paragraph fields as well.
   if ($variables['field_type'] == 'entity_reference_revisions' && $is_paragraph && $has_items) {
     foreach ($variables['items'] as &$pitem) {
       $paragraph_type = $pitem['content']['#paragraph']->getType();


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Using bricks fields breaks in the preprocess field.

# Needed By (Date)
- asap

# Urgency
- mild

# Steps to Test
1. checkout branch. clear cache
2. verify it still adds the class to earth fields

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)