### PR TITLE
Change type on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,12 @@
 {
   "name": "su-sws/stanford_basic",
   "description": "Stanford Basic Branding Theme.",
-  "type": "stanford-theme",
+  "type": "drupal-custom-theme",
   "homepage": "https://github.com/SU-SWS/stanford_basic",
   "authors": [],
   "license": "GPL-2.0+",
   "minimum-stability": "dev",
-  "require": {}
+  "require": {
+    "composer/installers" : "~1.0"
+  }
 }


### PR DESCRIPTION
With composer/installers and type: drupal-custom-theme, this theme would automatically be installed in /modules/custom when required by a Drupal project. The original stanford-theme type wasn't recognized and so the theme was installed in the /vendor directory. 