### PR TITLE
corrected validation errors on footer and regions

### DIFF
--- a/templates/components/global-footer.html.twig
+++ b/templates/components/global-footer.html.twig
@@ -8,7 +8,7 @@
   <div class="decanter-grid">
     <div class="decanter-width-one-sixth">
       <div id="global-footer__brand"> <a href="http://www.stanford.edu/" class="su-brand">
-          <object data="/{{ stanford_basic_path }}/assets/svg/su_sig_stack_linked.svg" alt="Stanford University" width="105" height="49" tabindex="-1">Stanford University Logo</object>
+          <object data="/{{ stanford_basic_path }}/assets/svg/su_sig_stack_linked.svg" width="105" height="49">Stanford University Logo</object>
         </a>
       </div>
     </div>
@@ -24,7 +24,7 @@
           <a href="https://www.stanford.edu/site/terms/" title="{{ 'Terms of use for sites'|t }}">{{ 'Terms of Use'|t }}</a>
           <a href="https://www.stanford.edu/site/privacy/" title="{{ 'Privacy and cookie policy'|t }}">{{ 'Privacy'|t }}</a>
           <a href="https://uit.stanford.edu/security/copyright-infringement" title="{{ 'Report alleged copyright infringement'|t }}">{{ 'Copyright'|t }}</a>
-          <a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4" title="{{ 'Ownership and use of Stanford trademarks and images'|t }}">{{ 'Trademark'|t }}</a>
+          <a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4" title="{{ 'Ownership and use of Stanford trademarks and images'|t }}">{{ 'Trademarks'|t }}</a>
           <a href="http://exploredegrees.stanford.edu/nonacademicregulations/nondiscrimination/" title="{{ 'Non-discrimination policy'|t }}">{{ 'Non-Discrimination'|t }}</a>
           <a href="https://www.stanford.edu/site/accessibility" title="{{ 'Report web accessibility issues'|t }}">{{ 'Accessibility'|t }}</a>
         </nav>

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -13,7 +13,7 @@
   </div>
 
   {% if page.menu %}
-    <div id=" menu-region">
+    <div id="menu-region">
       {{ page.menu }}
     </div>
   {% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- HTML Validation errors on the footer logo
- changed `Trademark` to plural
- removed bad space in id element

# Needed By (Date)
- whenever

# Urgency
- low

# Steps to Test
1. Manual review is all thats necessary.
HTML errors can be seen on https://d.pr/free/i/BS00PI


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)