### PR TITLE
ARCH-318 fix global brand bar

### DIFF
--- a/css/components/brand-bar.css
+++ b/css/components/brand-bar.css
@@ -25,9 +25,9 @@
   color: #ffffff;
   height: 40px;
   line-height: 50px;
-  max-height: 40px;
-  order: -100; }
+  max-height: 40px; }
   .brand-bar img {
-    width: 153px; }
+    display: inline-block;
+    width: 163px; }
 
 /*# sourceMappingURL=brand-bar.css.map */

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -25,10 +25,10 @@
   color: #ffffff;
   height: 40px;
   line-height: 50px;
-  max-height: 40px;
-  order: -100; }
+  max-height: 40px; }
   .brand-bar img {
-    width: 153px; }
+    display: inline-block;
+    width: 163px; }
 
 [class^="su-brand"], [class*=" su-brand"] {
   /* use !important to prevent issues with browser extensions that change fonts */

--- a/scss/components/brand-bar.scss
+++ b/scss/components/brand-bar.scss
@@ -4,8 +4,6 @@
 // Stanford Global Brand Bar
 //
 
-// A thin red stripe with the Stanford logo.
-
 // Decanter.
 @import
   'decanter-no-markup';
@@ -15,8 +13,7 @@
   'config/config',
   'utilities/utilities';
 
-// Mixin for easy re-use
-@mixin stanford-brand-bar {
+.brand-bar {
   background: $color-bright-red;
   color: $color-white;
   height: 40px;
@@ -24,13 +21,7 @@
   max-height: 40px;
 
   img {
-    width: 153px;
+    display: inline-block;
+    width: 163px;
   }
-}
-
-// Separation of class from mixin
-.brand-bar {
-  @include stanford-brand-bar;
-
-  order: -100;
 }

--- a/scss/components/navigation.scss
+++ b/scss/components/navigation.scss
@@ -4,7 +4,6 @@
 // Navigation
 //
 
-// Navigation styles
 #navigation {
   li {
     list-style-type: none;

--- a/scss/components/site-name.scss
+++ b/scss/components/site-name.scss
@@ -4,7 +4,6 @@
 // Site Name
 //
 
-// Site name
 .site-name {
   font-size: 2.2em;
   line-height: 1.3em;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Cleaned up Global Brand Bar styles, namely overriding the default display for images
- Minor clean up for uniformity on other component comments

# Needed By (Date)
- End of sprint (8/16)

# Urgency
- N/A

# Steps to Test

1. Pull this branch.
2. Test to make sure that the Stanford University img/logo is now vertically centered within the container rather than touching the top.

# Affected Projects or Products
- Archaeology
- All future sites using theme
- suhumsci (theme)

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/ARCH-318

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)