### PR TITLE
set images without an alt to get a aria role instead

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -134,3 +134,13 @@ function stanford_basic_preprocess_views_view(&$variables) {
 function _stanford_basic_change_characters($string) {
   return preg_replace("/[^a-zA-Z\d\s]/", '-', $string);
 }
+
+/**
+ * Implements hook_preprocess_image().
+ */
+function stanford_basic_preprocess_image(&$vars) {
+  // Decorative images get the role="presentation" attribute.
+  if (!isset($vars['attributes']['alt'])) {
+    $vars['attributes']['role'] = 'presentation';
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Images without an alt get the `role="presentation"` to indicate it is a decorative image.

# Needed By (Date)
- someday

# Urgency
- low

# Steps to Test

1. checkout this branch
2. clear cache
3. add an image via a field/media to a page without an alt
4. ensure that page has `role="presentation"` attribute.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)