### PR TITLE
Twig concat doesnt use +. changed it to a ~

### DIFF
--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -14,7 +14,7 @@
   Add that logic here.
 #}
 {% if content.site_slogan|render|striptags is not empty %}
-{% set classes = classes + " su-lockup--two-lines" %}
+  {% set classes = classes ~ " su-lockup--two-lines" %}
 {% endif %}
 
 {#


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed concat from + to ~... the correct way
- fixes an error that occurs `Warning: A non-numeric value encountered in __TwigTemplate_....`

# Needed By (Date)
- soon

# Urgency
- low

# Steps to Test
1. checkout this branch.
1. clear render caches
1. validate the class still functions correctly.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)