### PR TITLE
D8CORE-1211: Ensure aria-current matches on main menu active items.

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -273,16 +273,13 @@ function stanford_basic_preprocess_menu(&$variables, $hook) {
  */
 function _stanford_basic_menu_process_submenu(&$submenu, $current_path) {
   foreach ($submenu as &$item) {
+    $item_path = (is_string($item['url'])) ? $item['url'] : $item['url']->toString();
+    if ($item_path == $current_path) {
+      $item['is_active'] = TRUE;
+    }
 
-    if ($item['in_active_trail']) {
-      $item_path = (is_string($item['url'])) ? $item['url'] : $item['url']->toString();
-
-      if ($item_path == $current_path) {
-        $item['is_active'] = TRUE;
-      }
-      elseif (count($item['below'])) {
-        _stanford_basic_menu_process_submenu($item['below'], $current_path);
-      }
+    if ($item['in_active_trail'] && count($item['below'])) {
+      _stanford_basic_menu_process_submenu($item['below'], $current_path);
     }
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix up the logic in the preprocess to ensure that all primary menu items and secondary items get the appropriate aria roles and classes.

# Review By (Date)
- Jan 29th

# Urgency
- Medium low

# Steps to Test

1. Build a site and navigate to the home page
2. Inspect the home link in the primary nav
3. See no aria-current attribute
4. Check out this branch and clear all caches
5. Re-inspect the home link and now see the aria-current attribute. 
6. Validate on other links by navigating to their page and inspecting their attributes.

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1121

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)