### PR TITLE
D8CORE-723: Add skip to main content option above secondary navigation.

### DIFF
--- a/templates/menus/menu--secondary-nav.html.twig
+++ b/templates/menus/menu--secondary-nav.html.twig
@@ -18,6 +18,7 @@
 {% set attributes = attributes.setAttribute('aria-label', aria_label|default('secondary menu')) %}
 {# Macros #}
 {%- import "@basic/menus/macros/secondary-nav-menu.twig" as menus -%}
+<a href="#main-content" class="visually-hidden focusable su-skipnav">{{ 'Skip to main content'|t }}</a>
 <nav{{ attributes }}>
   {% spaceless %}
   {% if items is iterable %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add skip to main content skiplink above secondary navigation

# Review By (Date)
- Jan 29th

# Urgency
- Low

# Steps to Test

1. Check out this branch and clear caches
2. Navigate to a page with secondary navigation
3. Tab your way down to the secondary navigation
4. See skip link pop up prior to entering the secondary navigation

# Affected Projects or Products
- D8CORE
- https://github.com/SU-SWS/stanford_basic/pull/110

# Associated Issues and/or People
- D8CORE-723
- https://github.com/SU-SWS/stanford_basic/pull/110

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)