### PR TITLE
D8CORE-714: Remove duplicate class attribute on components.

### DIFF
--- a/templates/block/block--search-form-block.html.twig
+++ b/templates/block/block--search-form-block.html.twig
@@ -1,8 +1,9 @@
 {% set attributes = attributes.addClass('su-site-search') %}
-{% set action = base_path ~ "/search/node" %}
 
 {% include "@basic-dist/decanter/components/site-search/site-search.twig" with
   {
+    "attributes": attributes|without('class', 'role'),
+    "modifier_class": attributes.class,
     "action": content['#action'],
     "method": "get",
     "search_label": "Search this site"|t,

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -13,6 +13,7 @@
   The variant classes change when there is more than one line to render.
   Add that logic here.
 #}
+
 {% if lockup.option is not empty %}
   {% set attributes = attributes.addClass(["su-lockup", "su-lockup--option-" ~ lockup.option]) %}
 {% endif %}
@@ -33,7 +34,8 @@
 
 {%
   set data = {
-  'attributes': attributes,
+  'attributes': attributes|without('class'),
+  'modifier_class': attributes.class,
   'link': url('<front>'),
   'line1': line1,
   'line2': line2,

--- a/templates/content/media.html.twig
+++ b/templates/content/media.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Theme override to display a media item.
+ *
+ * Available variables:
+ * - name: Name of the media.
+ * - content: Media content.
+ *
+ * @see template_preprocess_media()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes }}>
+  {{ title_suffix.contextual_links }}
+  {% if content %}
+    {{ content }}
+  {% endif %}
+</div>

--- a/templates/core/status-messages.html.twig
+++ b/templates/core/status-messages.html.twig
@@ -25,7 +25,6 @@
 #}
 {% for type, messages in message_list %}
   {% set attributes = create_attribute() %}
-  {% set attributes = attributes.addClass('su-alert') %}
   {% set attributes = attributes.setAttribute('role', 'alert') %}
 
   {% if type == "status" %}
@@ -33,6 +32,9 @@
   {% else %}
     {% set attributes = attributes.addClass('su-alert--' ~ type) %}
   {% endif %}
+
+  {% set modifier_class = attributes.class %}
+  {% set attributes = attributes|without('class') %}
 
   {# Good for everyone. #}
   {% if status_headings[type] %}

--- a/templates/navigation/toolbar.html.twig
+++ b/templates/navigation/toolbar.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme override for the administrative toolbar.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the wrapper.
+ * - toolbar_attributes: HTML attributes to apply to the toolbar.
+ * - toolbar_heading: The heading or label for the toolbar.
+ * - tabs: List of tabs for the toolbar.
+ *   - attributes: HTML attributes for the tab container.
+ *   - link: Link or button for the menu tab.
+ * - trays: Toolbar tray list, each associated with a tab. Each tray in trays
+ *   contains:
+ *   - attributes: HTML attributes to apply to the tray.
+ *   - label: The tray's label.
+ *   - links: The tray menu links.
+ * - remainder: Any non-tray, non-tab elements left to be rendered.
+ *
+ * @see template_preprocess_toolbar()
+ */
+#}
+{% set toolbar_attributes = toolbar_attributes.removeAttribute('role') %}
+{% extends '@stable/navigation/toolbar.html.twig' %}

--- a/templates/node.html.twig
+++ b/templates/node.html.twig
@@ -7,8 +7,14 @@
 {% set title_classes = [ node.bundle|clean_class ~ '__title'] %}
 {% set attributes = attributes.addClass(node_classes) %}
 {% set attributes = attributes.removeAttribute('role') %}
-<article{{ attributes }}>
 
+{% if page %}
+{# Node as a page should be a section. #}
+<section{{ attributes }}>
+{# Node in a list should be it's own article. #}
+{% else %}
+<article{{ attributes }}>
+{% endif %}
   {% if title_prefix or title_suffix or display_submitted or unpublished or page is empty and label %}
     <header>
       {{ title_prefix }}
@@ -43,4 +49,8 @@
     </div><!-- /.links -->
   {% endif %}
 
-</article><!-- /.node -->
+{% if page %}
+</section><!-- /.node as page -->
+{% else %}
+</article><!-- /.node as a list -->
+{% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removes duplicate attributes from components
- Updates semantics based on comments by level access
-- Removes article wrapper from media template (previously using stable's template)
-- Creates toggle between page and list markup for nodes.

# Review By (Date)
- January, 30th

# Urgency
- Med/Low - Accessibility fixes must get in but it is not blocking anyone else

# Steps to Test

1. Check out this branch
2. Do a fresh install of stanford_profile (or clear cache on your existing)
3. Review the markup on a media item, node, status messages, search form, and lockup. 
4. You can use the W3C NU validator

# Affected Projects or Products
- D8CORE and everything else D8 using this theme

# Associated Issues and/or People
- D8CORE-714
- D8CORE-929
- @katrialesser JUST FYI

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)# NOT READY