### PR TITLE
Add missing dependency on jquery.

### DIFF
--- a/stanford_basic.libraries.yml
+++ b/stanford_basic.libraries.yml
@@ -108,6 +108,7 @@ basic:
     - classy/messages
     - classy/progress
     - core/drupal
+    - core/jquery
     - core/modernizr
     - stanford_basic/fontawesome
 


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Adds missing dependency on jquery 
- The fix for the skip links requires it and it is not loaded for anon

# Review By (Date)
- End of the day Friday?

# Urgency
- Low, but it causes a console error.

# Steps to Test

1. Do a build and install from 1.x of cardinalsites
2. View the home page as anonymous
3. Tab until you get to the `skip to secondary navigation` skiplink. See browser console log for error.
4. Check out this branch
5. Clear caches and reload the home page as anonymous 
6. Tab and no longer get to secondary links option. 

# Affected Projects or Products
- This

# Associated Issues and/or People
- D8CORE

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
