### PR TITLE
D8CORE-1327: fixing the header lockup to have special characters

### DIFF
--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -20,16 +20,16 @@
 
 {# Do not default the line 1 on variant O, S, or T #}
 {% if lockup.option != "o" and lockup.option != "s" and lockup.option != "t" %}
-  {% set line1 = content.site_name|render|striptags %}
+  {% set line1 = content.site_name|render|raw %}
 {% endif %}
 
 {% if lockup.line1 is not empty %}
- {% set line1 = lockup.line1|render|striptags %}
+ {% set line1 = lockup.line1|render|raw %}
 {% endif %}
 
-{% set line2 = content.site_slogan|render|striptags %}
+{% set line2 = content.site_slogan|render|raw %}
 {% if lockup.line2 is not empty %}
- {% set line2 = lockup.line2|render|striptags %}
+ {% set line2 = lockup.line2|render|raw %}
 {% endif %}
 
 {%
@@ -39,9 +39,9 @@
   'link': url('<front>'),
   'line1': line1,
   'line2': line2,
-  'line3': lockup.line3|render|striptags,
-  'line4': lockup.line4|render|striptags,
-  'line5': lockup.line5|render|striptags
+  'line3': lockup.line3|render|raw,
+  'line4': lockup.line4|render|raw,
+  'line5': lockup.line5|render|raw
   }
 %}
 {% include "@basic-dist/decanter/components/lockup/lockup.twig" with data only %}

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -20,16 +20,16 @@
 
 {# Do not default the line 1 on variant O, S, or T #}
 {% if lockup.option != "o" and lockup.option != "s" and lockup.option != "t" %}
-  {% set line1 = content.site_name|render|raw %}
+  {% set line1 = content.site_name %}
 {% endif %}
 
 {% if lockup.line1 is not empty %}
- {% set line1 = lockup.line1|render|raw %}
+ {% set line1 = lockup.line1 %}
 {% endif %}
 
-{% set line2 = content.site_slogan|render|raw %}
+{% set line2 = content.site_slogan %}
 {% if lockup.line2 is not empty %}
- {% set line2 = lockup.line2|render|raw %}
+ {% set line2 = lockup.line2 %}
 {% endif %}
 
 {%
@@ -39,9 +39,9 @@
   'link': url('<front>'),
   'line1': line1,
   'line2': line2,
-  'line3': lockup.line3|render|raw,
-  'line4': lockup.line4|render|raw,
-  'line5': lockup.line5|render|raw
+  'line3': lockup.line3,
+  'line4': lockup.line4,
+  'line5': lockup.line5
   }
 %}
 {% include "@basic-dist/decanter/components/lockup/lockup.twig" with data only %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Currently, html entities are encoded and passed into the twig templates rendering & as &amp; This is particularly a problem for the header and footer's lockup.

# Review By (Date)
- Thursday 

# Urgency
- Med/Low

# Steps to Test

1. Set the site name to Bugs & 'Bunny'
2. Clear cache and review the local footer lockup
3. See double encoding of the &
4. See the ' encoded.
5. Check out this branch and import config
6. Clear cache and see only the & and the '
6. Shea fixed up the double encoding in the config.

# Affected Projects or Products
- D8CORE-1327

# Associated Issues and/or People
- D8CORE-1327
- https://github.com/SU-SWS/stanford_profile/pull/123
- https://github.com/SU-SWS/jumpstart_ui/compare/D8CORE-1327
- @sherakama 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
