### PR TITLE
D8CORE-1504: Remove ids from pattern templates.

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -8,8 +8,6 @@
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\layout_builder\Plugin\SectionStorage\DefaultsSectionStorage;
 use Drupal\Component\Utility\Html;
-use Drupal\ui_patterns\UiPatterns;
-use Drupal\ui_patterns\Element\PatternContext;
 use Drupal\Core\Url;
 
 /**
@@ -149,31 +147,6 @@ function stanford_basic_preprocess_image(&$vars) {
   // Decorative images get the role="presentation" attribute.
   if (!isset($vars['attributes']['alt'])) {
     $vars['attributes']['role'] = 'presentation';
-  }
-}
-
-/**
- * Implements hook_preprocess().
- */
-function stanford_basic_preprocess(&$variables, $hook) {
-  // Only want pattern contexts.
-  if (isset($variables['context']) && !($variables['context'] instanceof PatternContext)) {
-    return;
-  }
-
-  foreach (UiPatterns::getPatternDefinitions() as $pattern_id => $pattern) {
-    if (strpos($hook, $pattern_id) !== FALSE) {
-
-      if (isset($variables['attributes']['id'])) {
-        $variables['attributes']['id'] = Html::getUniqueId($variables['attributes']['id']);
-      }
-
-      $definition = $pattern->toArray();
-      if (isset($variables['variant']) && isset($definition['variants'][$variables['variant']]['modifier_class'])) {
-        $variables['modifier_class'] = $definition['variants'][$variables['variant']]['modifier_class'];
-      }
-      break;
-    }
   }
 }
 

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -162,6 +162,11 @@ function stanford_basic_preprocess(&$variables, $hook) {
 
   foreach (UiPatterns::getPatternDefinitions() as $pattern_id => $pattern) {
     if (strpos($hook, $pattern_id) !== FALSE) {
+
+      if (isset($variables['attributes']['id'])) {
+        $variables['attributes']['id'] = Html::getUniqueId($pattern_id);
+      }
+
       $definition = $pattern->toArray();
       if (isset($variables['variant']) && isset($definition['variants'][$variables['variant']]['modifier_class'])) {
         $variables['modifier_class'] = $definition['variants'][$variables['variant']]['modifier_class'];

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -164,7 +164,7 @@ function stanford_basic_preprocess(&$variables, $hook) {
     if (strpos($hook, $pattern_id) !== FALSE) {
 
       if (isset($variables['attributes']['id'])) {
-        $variables['attributes']['id'] = Html::getUniqueId($pattern_id);
+        $variables['attributes']['id'] = Html::getUniqueId($variables['attributes']['id']);
       }
 
       $definition = $pattern->toArray();

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -162,16 +162,10 @@ function stanford_basic_preprocess(&$variables, $hook) {
 
   foreach (UiPatterns::getPatternDefinitions() as $pattern_id => $pattern) {
     if (strpos($hook, $pattern_id) !== FALSE) {
-      $ids = &drupal_static(__FUNCTION__, []);
-      if (!isset($ids[$pattern_id])) {
-        $ids[$pattern_id] = 0;
-      }
-
       $definition = $pattern->toArray();
       if (isset($variables['variant']) && isset($definition['variants'][$variables['variant']]['modifier_class'])) {
         $variables['modifier_class'] = $definition['variants'][$variables['variant']]['modifier_class'];
       }
-
       break;
     }
   }

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -167,10 +167,6 @@ function stanford_basic_preprocess(&$variables, $hook) {
         $ids[$pattern_id] = 0;
       }
 
-      if (!isset($variables['attributes']['id'])) {
-        $variables['attributes']['id'] = Html::getUniqueId($pattern_id);
-      }
-
       $definition = $pattern->toArray();
       if (isset($variables['variant']) && isset($definition['variants'][$variables['variant']]['modifier_class'])) {
         $variables['modifier_class'] = $definition['variants'][$variables['variant']]['modifier_class'];

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -9,6 +9,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\layout_builder\Plugin\SectionStorage\DefaultsSectionStorage;
 use Drupal\Component\Utility\Html;
 use Drupal\ui_patterns\UiPatterns;
+use Drupal\ui_patterns\Element\PatternContext;
 use Drupal\Core\Url;
 
 /**
@@ -155,8 +156,8 @@ function stanford_basic_preprocess_image(&$vars) {
  * Implements hook_preprocess().
  */
 function stanford_basic_preprocess(&$variables, $hook) {
-  $moduleHandler = \Drupal::service('module_handler');
-  if (!$moduleHandler->moduleExists('ui_patterns')) {
+  // Only want pattern contexts.
+  if (isset($variables['context']) && !($variables['context'] instanceof PatternContext)) {
     return;
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- IDs are hard to guarantee uniqueness so stop trying
- We don't encourage the use of them anyhow
- Anything that should be dependant on it should be javascript and we don't have much of that. 

# Review By (Date)
- Sometime

# Urgency
- Med/Low

# Steps to Test

1. Do a build or use your existing build
2. Add several of the same paragraph types to the page. Eg: Media with a caption.
3. Review the code and see many ids. Some perhaps duplicated.
4. Check out this branch
5. Check out D8CORE-1504 of jumpstart_ui
6. Clear cache
7. Review markup for no more IDs.
8. Think hard and try to remember if there is anything that would be dependant on these IDs.

# Affected Projects or Products
- D8CORE
- Jumpstart UI
- Accessibility Epic

# Associated Issues and/or People
- D8CORE-1504
- https://github.com/SU-SWS/jumpstart_ui/pull/46

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
