### PR TITLE
D8CORE-000 Provide a default lockup option

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -216,7 +216,7 @@ function _stanford_basic_preprocess_not_nodes(&$vars) {
  * Pass through the lockup configuration settings.
  */
 function stanford_basic_preprocess_block__system_branding_block(&$vars) {
-  $vars['lockup'] = theme_get_setting('lockup');
+  $vars['lockup'] = theme_get_setting('lockup') ?: 'a';
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- With subthemes if the subtheme hasn't defined the lockup style option, it won't get appropriate styles and it will look wrong. This makes sure that there is always at least option `a` applied.

# Need Review By (Date)
- :shrug: 

# Urgency
- low

# Steps to Test
1. checkout the `8.x-4.x` branch.
1. `drush cdel stanford_basic.settings`
1. view the lockup and see how it doesn't look correct
1. checkout this branch and clear render caches
1. validate the lockup at least has the correct styles for option "a"

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
