### PR TITLE
D8CORE-1406: remove link, move page-content ID

### DIFF
--- a/templates/page--user--login.html.twig
+++ b/templates/page--user--login.html.twig
@@ -4,8 +4,7 @@
   {{ page.help }}
 {%- endif -%}
 
-<div class="page-content">
-  <a name="page-content" id="page-content" tabindex="-1" class="visually-hidden focusable">Page Content</a>
+<div class="page-content" id="page-content">
   {{ page.content }}
 </div>
 

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -18,8 +18,7 @@
   </section>
 </header>
 
-<div class="page-content">
-  <a name="page-content" id="page-content" tabindex="-1" class="visually-hidden focusable">Page Content</a>
+<div class="page-content" id="page-content">
   {{ page.content }}
 </div>
 


### PR DESCRIPTION
# READY FOR REVIEW
On the search page (see https://amptesting.sites.stanford.edu/search/content ), the current approach to "skip to main content" is not working as expected. I'm giving this approach a try.

# Summary

Here's a comparison as to how it is working:
https://stanford.zoom.us/rec/share/vZNTKJDa6mxJGa-RyVjOQPEjXbX3aaa80SFP-KFenUioTSFgbRnhrtQIGUF96YiV

In this article, https://webaim.org/techniques/skipnav/#maincontent, they mention 2 approaches to the "skip to main content link" the second approach is _similar_ to the original, but note that the `<a>` tag is wrapped _inside_ the `<h1>`. Our current approach has the `<a>` as a _child_ of the `<div class='page-content'>`.

When inspecting the page at https://webaim.org/techniques/skipnav/ , the approach I've taken in this PR mirrors the approach on this page. 


# Review By (Date)
Soon

# Urgency
Fixes an accessibility issue. 

# Steps to Test

1. check out this branch
1. Turn on VoiceOver
1. Navigate from "Skip to main content" to the main content.
1. Verify it works as expected.

# Affected Projects or Products
d8core

# Associated Issues and/or People
- JIRA ticket
  - https://stanfordits.atlassian.net/browse/D8CORE-1406
  - https://stanfordits.atlassian.net/browse/D8CORE-1448
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
