### PR TITLE
Add blocks for extending stanford_basic

### DIFF
--- a/templates/content/media.html.twig
+++ b/templates/content/media.html.twig
@@ -14,7 +14,5 @@
 #}
 <div{{ attributes }}>
   {{ title_suffix.contextual_links }}
-  {% if content %}
-    {{ content }}
-  {% endif %}
+  {{ content }}
 </div>

--- a/templates/core/status-messages.html.twig
+++ b/templates/core/status-messages.html.twig
@@ -23,6 +23,13 @@
  * @see template_preprocess_status_messages()
  */
 #}
+
+{# Template Paths #}
+{%- if template_alert is empty -%}
+  {% set template_alert = "@basic-dist/decanter/components/alert/alert.twig" %}
+{%- endif -%}
+{# End Template Paths. #}
+
 {% for type, messages in message_list %}
   {% set attributes = create_attribute() %}
   {% set attributes = attributes.setAttribute('role', 'alert') %}
@@ -82,6 +89,6 @@
       'alert_dismiss': true
       }
     %}
-    {% include "@basic-dist/decanter/components/alert/alert.twig" with data only %}
+    {% include template_alert with data only %}
   {% endfor %}
 {% endfor %}

--- a/templates/html.html.twig
+++ b/templates/html.html.twig
@@ -89,18 +89,16 @@
     {% set classes = classes|merge(['role--' ~ role|clean_class]) %}
   {% endfor %}
   <body{{ attributes.addClass(classes) }}>
-    {% block skipLinksMain %}
+    {% block block_skiplinks %}
       <a href="#main-content" class="visually-hidden focusable su-skipnav su-skipnav--content">
         {{ 'Skip to main content'|t }}
       </a>
-    {% endblock %}
-    {% block skipLinksNavigation %}
       <a href="#secondary-navigation" class="visually-hidden focusable su-skipnav su-skipnav--secondary">
         {{ 'Skip to secondary navigation'|t }}
       </a>
     {% endblock %}
 
-  {{ page_top }}
+    {{ page_top }}
     {{ page }}
     {{ page_bottom }}
     <js-bottom-placeholder token="{{ placeholder_token }}">

--- a/templates/html.html.twig
+++ b/templates/html.html.twig
@@ -89,13 +89,16 @@
     {% set classes = classes|merge(['role--' ~ role|clean_class]) %}
   {% endfor %}
   <body{{ attributes.addClass(classes) }}>
+    {% block skiplinks %}
       <a href="#main-content" class="visually-hidden focusable su-skipnav su-skipnav--content">
         {{ 'Skip to main content'|t }}
       </a>
       <a href="#secondary-navigation" class="visually-hidden focusable su-skipnav su-skipnav--secondary">
         {{ 'Skip to secondary navigation'|t }}
       </a>
-    {{ page_top }}
+    {% endblock %}
+
+  {{ page_top }}
     {{ page }}
     {{ page_bottom }}
     <js-bottom-placeholder token="{{ placeholder_token }}">

--- a/templates/html.html.twig
+++ b/templates/html.html.twig
@@ -89,10 +89,12 @@
     {% set classes = classes|merge(['role--' ~ role|clean_class]) %}
   {% endfor %}
   <body{{ attributes.addClass(classes) }}>
-    {% block skiplinks %}
+    {% block skipLinksMain %}
       <a href="#main-content" class="visually-hidden focusable su-skipnav su-skipnav--content">
         {{ 'Skip to main content'|t }}
       </a>
+    {% endblock %}
+    {% block skipLinksNavigation %}
       <a href="#secondary-navigation" class="visually-hidden focusable su-skipnav su-skipnav--secondary">
         {{ 'Skip to secondary navigation'|t }}
       </a>

--- a/templates/node.html.twig
+++ b/templates/node.html.twig
@@ -8,6 +8,12 @@
 {% set attributes = attributes.addClass(node_classes) %}
 {% set attributes = attributes.removeAttribute('role') %}
 
+{# Template Paths #}
+{%- if template_alert is empty -%}
+  {%- set template_alert = "@basic-dist/decanter/components/alert/alert.twig" -%}
+{%- endif -%}
+{# End Template Paths #}
+
 {% if page %}
 {# Node as a page should be a section. #}
 <section{{ attributes }}>
@@ -17,43 +23,52 @@
 {% endif %}
   {% if title_prefix or title_suffix or display_submitted or unpublished or page is empty and label %}
     <header>
+
+      {# Title Prefix #}
       {{ title_prefix }}
-      {% if not page and label %}
+
+      {%- if not page and label -%}
         <h2{{ title_attributes.addClass(title_classes) }}>
           <a href="{{ url }}" rel="bookmark">{{ label }}</a>
         </h2>
-      {% endif %}
+      {%- endif -%}
+
+      {# Title Suffix #}
       {{ title_suffix }}
 
-      {% if display_submitted %}
+      {# Display Submitted #}
+      {%- if display_submitted -%}
         <div class="submitted">
           {{ author_picture }}
           {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
           {{ metadata }}
         </div>
-      {% endif %}
+      {%- endif -%}
 
-      {% if not node.published %}
-        {%
+      {# Unpublished Warning. #}
+      {%- if not node.published -%}
+        {%-
           set data = {
           'attributes': create_attribute({'class': 'su-alert su-alert--warning'}),
           'alert_text': "This page is currently unpublished and not visible to the public."|t,
         }
-        %}
-        {% include "@basic-dist/decanter/components/alert/alert.twig" with data %}
-      {% endif %}
-    </header>
-  {% endif %}
+        -%}
+        {%- include template_alert with data only -%}
+      {%- endif -%}
 
+    </header>
+  {%- endif -%}
+
+  {# Main content container. #}
   <div{{ content_attributes.addClass('content') }}>
     {{ content|without('links') }}
   </div><!-- /.content -->
 
-  {% if content.links %}
+  {%- if content.links -%}
     <div class="links">
       {{ content.links }}
     </div><!-- /.links -->
-  {% endif %}
+  {%- endif -%}
 
 {% if page %}
 </section><!-- /.node as page -->

--- a/templates/page--user--login.html.twig
+++ b/templates/page--user--login.html.twig
@@ -1,14 +1,18 @@
 {% extends "page.html.twig" %}
-{# same brandbar block -- inheritted now #}
-{# same help block -- inheritted now #}
 
-{% block header %}
-    <section>
-    {%- if page.header -%}
-      {{ page.header }}
-    {%- endif -%}
-    </section>
+{# Remove Nav and Search. #}
+{%- block block_header -%}
+  {%- if page.header -%}
+    <header class="su-masthead su-masthead--right">
+      <section>
+        {{ page.header }}
+      </section>
+    </header>
+  {%- endif -%}
+{%- endblock -%}
+
+{% block block_footer %}
+<footer id="footer">
+  {%- include template_global_footer -%}
+</footer>
 {% endblock %}
-
-{# same main block -- inheritted now #}
-{# same footer block -- inheritted now #}

--- a/templates/page--user--login.html.twig
+++ b/templates/page--user--login.html.twig
@@ -1,7 +1,5 @@
 {% extends "page.html.twig" %}
-
 {# same brandbar block -- inheritted now #}
-
 {# same help block -- inheritted now #}
 
 {% block header %}
@@ -15,5 +13,4 @@
 {% endblock %}
 
 {# same main block -- inheritted now #}
-
 {# same footer block -- inheritted now #}

--- a/templates/page--user--login.html.twig
+++ b/templates/page--user--login.html.twig
@@ -3,13 +3,11 @@
 {# same help block -- inheritted now #}
 
 {% block header %}
-  <header class="su-masthead su-masthead--right">
-      <section>
-      {%- if page.header -%}
-        {{ page.header }}
-      {%- endif -%}
-      </section>
-  </header>
+    <section>
+    {%- if page.header -%}
+      {{ page.header }}
+    {%- endif -%}
+    </section>
 {% endblock %}
 
 {# same main block -- inheritted now #}

--- a/templates/page--user--login.html.twig
+++ b/templates/page--user--login.html.twig
@@ -1,20 +1,46 @@
-{%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } -%}
+{% extends "page.html.twig" %}
 
-{%- if page.help -%}
-  {{ page.help }}
-{%- endif -%}
-<header class="su-masthead su-masthead--right">
-  <section>
-  {%- if page.header -%}
-    {{ page.header }}
-  {%- endif -%}
-  </section>
-</header>
 
-<div class="page-content" id="page-content">
-  {{ page.content }}
-</div>
+{# same brandbar block #}
+{#{% block brandbar %}#}
+{#  {%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } -%}#}
+{#{% endblock %}#}
 
-<footer id="footer">
-  {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
-</footer>
+{# same help block #}
+{#{% block help %}#}
+{#{%- if page.help -%}#}
+{#  {{ page.help }}#}
+{#{%- endif -%}#}
+{#{% endblock %}#}
+
+
+{% block header %}
+  <header class="su-masthead su-masthead--right">
+    {% block headerContent %}
+      <section>
+      {%- if page.header -%}
+        {{ page.header }}
+      {%- endif -%}
+      </section>
+    {% endblock %}
+  </header>
+{% endblock %}
+
+{# same main block #}
+{#{% block main %}#}
+{#  <main class="page-content" id="page-content">#}
+{#    {% block pageContent %}#}
+{#      {{ page.content }}#}
+{#    {% endblock %}#}
+{#  </main>#}
+{#{% endblock %}#}
+
+{# same footer block #}
+{#{% block footer %}#}
+{#  <footer id="footer">#}
+{#    {% block footerContent %}#}
+{#      {{ page.footer }}#}
+{#      {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}#}
+{#    {% endblock %}#}
+{#  </footer>#}
+{#{% endblock %}#}

--- a/templates/page--user--login.html.twig
+++ b/templates/page--user--login.html.twig
@@ -1,46 +1,19 @@
 {% extends "page.html.twig" %}
 
+{# same brandbar block -- inheritted now #}
 
-{# same brandbar block #}
-{#{% block brandbar %}#}
-{#  {%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } -%}#}
-{#{% endblock %}#}
-
-{# same help block #}
-{#{% block help %}#}
-{#{%- if page.help -%}#}
-{#  {{ page.help }}#}
-{#{%- endif -%}#}
-{#{% endblock %}#}
-
+{# same help block -- inheritted now #}
 
 {% block header %}
   <header class="su-masthead su-masthead--right">
-    {% block headerContent %}
       <section>
       {%- if page.header -%}
         {{ page.header }}
       {%- endif -%}
       </section>
-    {% endblock %}
   </header>
 {% endblock %}
 
-{# same main block #}
-{#{% block main %}#}
-{#  <main class="page-content" id="page-content">#}
-{#    {% block pageContent %}#}
-{#      {{ page.content }}#}
-{#    {% endblock %}#}
-{#  </main>#}
-{#{% endblock %}#}
+{# same main block -- inheritted now #}
 
-{# same footer block #}
-{#{% block footer %}#}
-{#  <footer id="footer">#}
-{#    {% block footerContent %}#}
-{#      {{ page.footer }}#}
-{#      {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}#}
-{#    {% endblock %}#}
-{#  </footer>#}
-{#{% endblock %}#}
+{# same footer block -- inheritted now #}

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,9 +1,15 @@
-{%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } -%}
+{% block brandbar %}
+  {%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } -%}
+{% endblock %}
 
+
+{% block help %}
 {%- if page.help -%}
   {{ page.help }}
 {%- endif -%}
+{% endblock %}
 
+{% block header %}
 <header class="su-masthead su-masthead--right">
   <section>
   {%- if page.header -%}
@@ -17,12 +23,17 @@
   {%- endif -%}
   </section>
 </header>
+{% endblock %}
 
+{% block main %}
 <main class="page-content" id="page-content">
   {{ page.content }}
 </main>
+{% endblock %}
 
-<footer id="footer">
-  {{ page.footer }}
-  {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
-</footer>
+{% block footer %}
+  <footer id="footer">
+    {{ page.footer }}
+    {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
+  </footer>
+{% endblock %}

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,38 +1,60 @@
-{% block brandbar %}
-  {%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } -%}
-{% endblock %}
+{#
+/**
+ * @file
+ * Main Page Template.
+ *
+ * Available variables:
+ * - page: The content regions for this page.
+ * - attributes: HTML attributes for the region div.
+ *
+ * @see template_preprocess_page()
+ */
+#}
 
-{% block help %}
-  {%- if page.help -%}
-    {{ page.help }}
-  {%- endif -%}
-{% endblock %}
+{# Template Paths #}
+{%- if template_brand_bar is empty -%}
+  {%- set template_brand_bar = "@basic-dist/decanter/components/brand-bar/brand-bar.twig" -%}
+{%- endif -%}
 
-<header class="su-masthead su-masthead--right">
-  {% block header %}
-    <section>
-      {%- if page.header -%}
+{%- if template_global_footer is empty -%}
+  {%- set template_global_footer = "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
+{%- endif -%}
+{# End Template Paths. #}
+
+{# Brand Bar #}
+{%- block block_brandbar -%}
+  {%- include template_brand_bar with { modifier_class : brand_bar_variant } -%}
+{%- endblock -%}
+
+{# Help Section #}
+{%- block block_help -%}
+  {{ page.help }}
+{%- endblock -%}
+
+{# Masthead Section. #}
+{%- block block_header -%}
+  {%- if page.header or page.search or page.menu -%}
+    <header class="su-masthead su-masthead--right">
+      <section>
         {{ page.header }}
-      {%- endif -%}
-      {%- if page.search -%}
         {{ page.search }}
-      {%- endif -%}
-      {%- if page.menu -%}
         {{ page.menu }}
-      {%- endif -%}
-    </section>
-  {% endblock %}
-</header>
+      </section>
+    </header>
+  {%- endif -%}
+{%- endblock -%}
 
+{# Main Page Content Section #}
 <main class="page-content" id="page-content">
-  {% block main %}
+  {%- block block_main -%}
     {{ page.content }}
-  {% endblock %}
+  {%- endblock -%}
 </main>
 
-<footer id="footer">
-  {% block footer %}
+{# Footer Section #}
+{%- block block_footer -%}
+  <footer id="footer">
     {{ page.footer }}
-    {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
-  {% endblock %}
-</footer>
+    {%- include template_global_footer -%}
+  </footer>
+{%- endblock -%}

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -2,38 +2,43 @@
   {%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } -%}
 {% endblock %}
 
-
 {% block help %}
-{%- if page.help -%}
-  {{ page.help }}
-{%- endif -%}
+  {%- if page.help -%}
+    {{ page.help }}
+  {%- endif -%}
 {% endblock %}
 
 {% block header %}
-<header class="su-masthead su-masthead--right">
-  <section>
-  {%- if page.header -%}
-    {{ page.header }}
-  {%- endif -%}
-  {%- if page.search -%}
-    {{ page.search }}
-  {%- endif -%}
-  {%- if page.menu -%}
-    {{ page.menu }}
-  {%- endif -%}
-  </section>
-</header>
+  <header class="su-masthead su-masthead--right">
+    {% block headerContent %}
+    <section>
+    {%- if page.header -%}
+      {{ page.header }}
+    {%- endif -%}
+    {%- if page.search -%}
+      {{ page.search }}
+    {%- endif -%}
+    {%- if page.menu -%}
+      {{ page.menu }}
+    {%- endif -%}
+    </section>
+    {% endblock %}
+  </header>
 {% endblock %}
 
 {% block main %}
-<main class="page-content" id="page-content">
-  {{ page.content }}
-</main>
+  <main class="page-content" id="page-content">
+    {% block pageContent %}
+      {{ page.content }}
+    {% endblock %}
+  </main>
 {% endblock %}
 
 {% block footer %}
   <footer id="footer">
-    {{ page.footer }}
-    {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
+    {% block footerContent %}
+      {{ page.footer }}
+      {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
+    {% endblock %}
   </footer>
 {% endblock %}

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -8,37 +8,31 @@
   {%- endif -%}
 {% endblock %}
 
-{% block header %}
-  <header class="su-masthead su-masthead--right">
-    {% block headerContent %}
+<header class="su-masthead su-masthead--right">
+  {% block header %}
     <section>
-    {%- if page.header -%}
-      {{ page.header }}
-    {%- endif -%}
-    {%- if page.search -%}
-      {{ page.search }}
-    {%- endif -%}
-    {%- if page.menu -%}
-      {{ page.menu }}
-    {%- endif -%}
+      {%- if page.header -%}
+        {{ page.header }}
+      {%- endif -%}
+      {%- if page.search -%}
+        {{ page.search }}
+      {%- endif -%}
+      {%- if page.menu -%}
+        {{ page.menu }}
+      {%- endif -%}
     </section>
-    {% endblock %}
-  </header>
-{% endblock %}
+  {% endblock %}
+</header>
 
-{% block main %}
-  <main class="page-content" id="page-content">
-    {% block pageContent %}
-      {{ page.content }}
-    {% endblock %}
-  </main>
-{% endblock %}
+<main class="page-content" id="page-content">
+  {% block main %}
+    {{ page.content }}
+  {% endblock %}
+</main>
 
-{% block footer %}
-  <footer id="footer">
-    {% block footerContent %}
-      {{ page.footer }}
-      {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
-    {% endblock %}
-  </footer>
-{% endblock %}
+<footer id="footer">
+  {% block footer %}
+    {{ page.footer }}
+    {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
+  {% endblock %}
+</footer>

--- a/templates/region.html.twig
+++ b/templates/region.html.twig
@@ -12,6 +12,4 @@
  * @see template_preprocess_region()
  */
 #}
-{% if content %}
-  {{ content }}
-{% endif %}
+{{ content }}

--- a/templates/search/search-result--node-search.html.twig
+++ b/templates/search/search-result--node-search.html.twig
@@ -62,6 +62,4 @@
   <a href="{{ url }}">{{ title }}</a>
 </h3>
 {{ title_suffix }}
-{%- if snippet -%}
-  {{ snippet }}
-{%- endif -%}
+{{ snippet }}


### PR DESCRIPTION
# READY

# Summary
- Adding twig blocks around sections in page template to make it easier to @extend the page template in subthemes.
- Background on this proposal for stanford basic is here: https://stanfordits.atlassian.net/browse/D8CORE-2677

# Review By (Date)
- Oct 10 

# Urgency
- medium/low

# Steps to Test

1. Pull down the branch
2. Clear the site cache
3. See that the page sections render properly. There shouldn't be visual changes. Review code in this pr and in the pr for saa_victoria_theme: https://github.com/SU-SWS/saa_victoria_subtheme/pull/106
4. Test that the login page correctly inherits from page.html.twig and doesn't appear any different.
5. Confirm that skip links can still be seen (now encapsulated by block tags).

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket  https://stanfordits.atlassian.net/browse/D8CORE-2677
- Prompted by / Related to this ADAPT Static Sites issue: https://stanfordits.atlassian.net/browse/ADAPT-687

