### PR TITLE
D8CORE-000: Protection from null object in menu

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -286,6 +286,7 @@ function _stanford_basic_link_is_public(Url $url) {
     if ($node) {
       return $node->isPublished();
     }
+    return TRUE;
   }
   return TRUE;
 }

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -283,7 +283,9 @@ function _stanford_basic_link_is_public(Url $url) {
     $parameters = $url->getRouteParameters();
     /** @var \Drupal\node\NodeInterface $node */
     $node = \Drupal::entityTypeManager()->getStorage('node')->load($parameters['node']);
-    return $node->isPublished();
+    if ($node) {
+      return $node->isPublished();
+    }
   }
   return TRUE;
 }


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Protects against null node_load
```
On https://aeroastrodrupal8.sites.stanford.edu, the following error presents:
php-error web-3889 [15-Sep-2020 12:07:57 America/Los_Angeles] Error: Call to a member function isPublished() on null in /mnt/www/html/lelandd801live/docroot/themes/custom/stanford_basic/stanford_basic.theme on line 286 #0 /mnt/www/html/lelandd801live/docroot/themes/custom/stanford_basic/stanford_basic.theme(259): _stanford_basic_link_is_public(Object(Drupal\Core\Url)) 
```

# Review By (Date)
- When does this need to be reviewed by?

# Urgency
- How critical is this PR?

# Steps to Test

1. Do this
1. Then this
2. Then this

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
