### PR TITLE
Wrap page contents with attributes

### DIFF
--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,28 +1,30 @@
-{%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } -%}
+{%- include "@basic-dist/decanter/components/brand-bar/brand-bar.twig" with { modifier_class : brand_bar_variant } only -%}
 
-{%- if page.help -%}
-  {{ page.help }}
-{%- endif -%}
-
-<header class="su-masthead su-masthead--right">
-  <section>
-  {%- if page.header -%}
-    {{ page.header }}
+<div{{ attributes }}>
+  {%- if page.help -%}
+    {{ page.help }}
   {%- endif -%}
-  {%- if page.search -%}
-    {{ page.search }}
-  {%- endif -%}
-  {%- if page.menu -%}
-    {{ page.menu }}
-  {%- endif -%}
-  </section>
-</header>
 
-<main class="page-content" id="page-content">
-  {{ page.content }}
-</main>
+  <header class="su-masthead su-masthead--right">
+    <section>
+    {%- if page.header -%}
+      {{ page.header }}
+    {%- endif -%}
+    {%- if page.search -%}
+      {{ page.search }}
+    {%- endif -%}
+    {%- if page.menu -%}
+      {{ page.menu }}
+    {%- endif -%}
+    </section>
+  </header>
 
-<footer id="footer">
-  {{ page.footer }}
-  {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
-</footer>
+  <main class="page-content" id="page-content">
+    {{ page.content }}
+  </main>
+
+  <footer id="footer">
+    {{ page.footer }}
+    {%- include "@basic-dist/decanter/components/global-footer/global-footer.twig" -%}
+  </footer>
+</div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Wrap the page contents in a div to allow attributes to be added
- pass `only` the brand bar variant to avoid inheritance of the rest of the attributes.

# Need Review By (Date)
- :shrug: 

# Urgency
- low

# Steps to Test
1. checkout this branch
1. create a `hook_preprocess_page` and add some attributes
1. see that the page has those attributes in a div.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
