### PR TITLE
D8CORE-2102: Add check to see if the path is part of the url

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -250,9 +250,10 @@ function stanford_basic_preprocess_menu(&$variables, $hook) {
  */
 function _stanford_basic_menu_process_submenu(&$submenu, $current_path) {
   foreach ($submenu as &$item) {
-
     $item_path = (is_string($item['url'])) ? $item['url'] : $item['url']->toString();
-    if ($item_path == $current_path || strpos($current_path, $item_path . '/') !== FALSE) {
+    if ($item_path == $current_path ||
+        strpos($current_path, $item_path . '/') !== FALSE ||
+        ($item_path == '/home' && $current_path == '/')) {
       $item['is_active'] = TRUE;
     }
 

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -253,7 +253,7 @@ function _stanford_basic_menu_process_submenu(&$submenu, $current_path) {
     $item_path = (is_string($item['url'])) ? $item['url'] : $item['url']->toString();
     if ($item_path == $current_path ||
         strpos($current_path, $item_path . '/') !== FALSE ||
-        ($item_path == '/home' && $current_path == '/')) {
+        ($item['title'] == 'Home' && \Drupal::service('path.matcher')->isFrontPage())) {
       $item['is_active'] = TRUE;
     }
 

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -289,7 +289,7 @@ function _stanford_basic_path_is_home(string $path) {
       $normal_path == '<front>') {
         return TRUE;
   }
-  return false;
+  return FALSE;
 }
 
 /**

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -249,7 +249,6 @@ function stanford_basic_preprocess_menu(&$variables, $hook) {
  * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
  */
 function _stanford_basic_menu_process_submenu(&$submenu, $current_path) {
-  $path_is_home = _stanford_basic_path_is_home('/');
   foreach ($submenu as &$item) {
     $item_path = (is_string($item['url'])) ? $item['url'] : $item['url']->toString();
     if ($item_path == $current_path ||

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -252,7 +252,7 @@ function _stanford_basic_menu_process_submenu(&$submenu, $current_path) {
   foreach ($submenu as &$item) {
 
     $item_path = (is_string($item['url'])) ? $item['url'] : $item['url']->toString();
-    if ($item_path == $current_path) {
+    if ($item_path == $current_path || strpos($current_path, $item_path . '/') !== FALSE) {
       $item['is_active'] = TRUE;
     }
 

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -249,11 +249,12 @@ function stanford_basic_preprocess_menu(&$variables, $hook) {
  * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
  */
 function _stanford_basic_menu_process_submenu(&$submenu, $current_path) {
+  $path_is_home = _stanford_basic_path_is_home('/');
   foreach ($submenu as &$item) {
     $item_path = (is_string($item['url'])) ? $item['url'] : $item['url']->toString();
     if ($item_path == $current_path ||
         strpos($current_path, $item_path . '/') !== FALSE ||
-        ($item['title'] == 'Home' && \Drupal::service('path.matcher')->isFrontPage())) {
+        (_stanford_basic_path_is_home($item_path) && \Drupal::service('path.matcher')->isFrontPage())) {
       $item['is_active'] = TRUE;
     }
 
@@ -265,6 +266,31 @@ function _stanford_basic_menu_process_submenu(&$submenu, $current_path) {
       _stanford_basic_menu_process_submenu($item['below'], $current_path);
     }
   }
+}
+
+/**
+ * Determine if a menu path corresponds to the current home page.
+ *
+ * @param string $path
+ *   The path given for a menu entry
+ *
+ * @return bool
+ *   TRUE if the path corresponds to the current home page.
+ */
+function _stanford_basic_path_is_home(string $path) {
+  // account for weird paths in input
+  $normal_path = strtolower(trim($path));
+  $config = \Drupal::config('system.site');
+  $front_uri = $config->get('page.front');
+  $alias = \Drupal::service('path.alias_manager')->getAliasByPath($front_uri);
+
+  if ($normal_path == base_path() ||
+      $normal_path == $front_uri ||
+      $normal_path == $alias ||
+      $normal_path == '<front>') {
+        return TRUE;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- In the menu, the active item is set by checking if the URL is identical to the path of the menu item. Here, we add a check to see if the menu item path is part of the URL.

# Review By (Date)
- next week.

# Urgency
- 1 out of 10

# Steps to Test

1. Check out this branch
2. `drush cr`.
3. Create a news story
4. Visit `/news`.  Notice the "News" item in the main menu is active.
5. Click through to the news story you created.  Notice that the "News" in the main menu is still active.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
