### PR TITLE
D8CORE-1366: Added tooltips to menu items which have a `description` set.

### DIFF
--- a/templates/menus/macros/nav-menu.twig
+++ b/templates/menus/macros/nav-menu.twig
@@ -13,12 +13,18 @@
     {% set link_attributes = link_attributes.addClass(class_prefix ~ "__link") %}
     {% set link_attributes = link_attributes.setAttribute('href', item.url|render) %}
 
+    {# Tooltips #}
+    {% if item.url.options.attributes.title is not empty %}
+      {% set link_attributes = link_attributes.setAttribute('data-toggle', 'tooltip') %}
+      {% set link_attributes = link_attributes.setAttribute('title', item.url.options.attributes.title) %}
+    {% endif %}
+
     {# Item Attributes #}
     {% set list_attributes = create_attribute() %}
     {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item") %}
     {% if item.below is not empty %}
       {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item--parent") %}
-      {% set link_attributes = link_attributes.setAttribute('aria-expanded', 'false') %} 
+      {% set link_attributes = link_attributes.setAttribute('aria-expanded', 'false') %}
     {% endif %}
     {% if item.in_active_trail == true %}
       {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item--active-trail") %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Tooltips were not displaying on nav menu items, even though a description was set.

# Review By (Date)
- soon

# Urgency
- not critical.

# Steps to Test

1. Checkout this branch into a working stack.
2. `drush cr` 
3. On any page, hover over "Research" in the menu. Notice no tool tip.
4. in `/admin/structure/menu/item/6/edit?destination=/admin/structure/menu/manage/main`, add some text to the Description field.
5. Save the menu.
6. Just to go belt + suspenders, do another `drush cr`.  
7. Hover over the "Research" link in the main menu again. Notice your description shows up as a tool tip.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?
  - nope.

# Associated Issues and/or People
- D8CORE-1366

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
