### PR TITLE
Hotfix: Removed code that matched partials paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Stanford Basic Theme
 
+8.x-4.13
+--------------------------------------------------------------------------------
+_Release Date: 2020-11-12_
+
+- D8CORE-3000: Hotfix to remove partial path matches in the menu for active classes.
+
+8.x-4.12
+--------------------------------------------------------------------------------
+_Release Date: 2020-11-09_
+
+- D8CORE-2592: removing the id that isn't used on sub menus (#193) (5db6f86)
+- D8CORE-2102: Add check to see if the path is part of the url (#190) (dbb43ab)
+- D8CORE-1073: A new way to move the search box into the mobile menu (#148) (17549b9)
+- D8CORE-1366: Added tooltips to menu items which have a `description` set. (#191) (b2fe939)
+
 8.x-4.11
 --------------------------------------------------------------------------------
 _Release Date: 2020-10-05_

--- a/stanford_basic.info.yml
+++ b/stanford_basic.info.yml
@@ -2,7 +2,7 @@ name: 'Stanford Basic'
 type: theme
 description: 'Stanford Basic Branding Theme.'
 package: Stanford
-version: 8.x-4.12-dev
+version: 8.x-4.13
 core_version_requirement: '^8 || ^9'
 'base theme': stable
 regions:

--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -252,7 +252,6 @@ function _stanford_basic_menu_process_submenu(&$submenu, $current_path) {
   foreach ($submenu as &$item) {
     $item_path = (is_string($item['url'])) ? $item['url'] : $item['url']->toString();
     if ($item_path == $current_path ||
-        strpos($current_path, $item_path . '/') !== FALSE ||
         (_stanford_basic_path_is_home($item_path) && \Drupal::service('path.matcher')->isFrontPage())) {
       $item['is_active'] = TRUE;
     }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed the check that matched partial paths from the URL to menu items.

# Review By (Date)
- ASAP

# Urgency
- needs to be in 1.5.0

# Steps to Test

1. checkout branch
2. create content with menu entries. You'll need at least three nested levels in the `main navigation` menu.
3. Verify when you are on the third level of the menu or below, only the top level and current item are marked as active.

# Affected Projects or Products
- stanford_basic and subthemes

# Associated Issues and/or People
- D8CORE-3000, D8CORE-2102
