### PR TITLE
Adjust `theme_get_setting` to target this theme, so that subthemes inherit it.

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -24,7 +24,7 @@ function stanford_basic_page_attachments_alter(array &$attachments) {
     $attachments['#attached']['library'][] = 'stanford_basic/user_login';
   }
   // Check if dropdown menus are activated
-  $attachments['#attached']['drupalSettings']['stanford_basic']['nav_dropdown_enabled'] = (theme_get_setting('nav_dropdown_enabled')) ? TRUE : FALSE;
+  $attachments['#attached']['drupalSettings']['stanford_basic']['nav_dropdown_enabled'] = (bool) theme_get_setting('nav_dropdown_enabled', 'stanford_basic');
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow children to inherit the dropdown settings.
- do we want to do this or require the subthemes to do their own settings?

# Need Review By (Date)
- today

# Urgency
- medium

# Steps to Test

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
