### PR TITLE
D8CORE-4496 Prevent empty <ul> elements in secondary nav

### DIFF
--- a/templates/menus/macros/secondary-nav-menu.twig
+++ b/templates/menus/macros/secondary-nav-menu.twig
@@ -3,44 +3,50 @@
  * Macro for creating nested menus.
  */
 #}
+
 {% macro secondary_nav_menu(items, menu_level, class_prefix, parent) %}
   {% import _self as menus %}
-  <ul class="{{ class_prefix }}__menu {{ class_prefix }}__menu-lv{{ menu_level }}">
-  {% for item in items %}
 
-    {# Link Attribtues #}
-    {% set link_attributes = item.attributes %}
-    {% set link_attributes = link_attributes.addClass(class_prefix ~ "__link") %}
-    {% set link_attributes = link_attributes.setAttribute('href', item.url|render) %}
+  {% set items_to_display = items|filter(item => item.in_active_trail == true or menu_level == 1 or parent.in_active_trail == true) %}
 
-    {# Item Attributes #}
-    {% set list_attributes = create_attribute() %}
-    {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item") %}
-    {% if item.below is not empty %}
-      {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item--parent") %}
-    {% endif %}
-    {% if item.in_active_trail == true %}
-      {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item--active-trail") %}
-    {% endif %}
-    {% if item.is_active == true %}
-      {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item--current") %}
-      {% set link_attributes = link_attributes.setAttribute('aria-current', 'true') %}
-    {% endif %}
+  {% if items_to_display is not empty %}
+    <ul class="{{ class_prefix }}__menu {{ class_prefix }}__menu-lv{{ menu_level }}">
+    {% for item in items_to_display %}
 
-    {# Skip non-trail items below the first level. #}
-    {% if item.in_active_trail == true or menu_level == 1 or parent.in_active_trail == true %}
-      <li{{ list_attributes }}>
-        <a{{ link_attributes }}>
-          {{ item.title }}
-          {% if item.unpublished %}
-            <div class="unpublished-indicator">{{ "Unpublished Page"|t }}</div>
+      {# Link Attribtues #}
+      {% set link_attributes = item.attributes %}
+      {% set link_attributes = link_attributes.addClass(class_prefix ~ "__link") %}
+      {% set link_attributes = link_attributes.setAttribute('href', item.url|render) %}
+
+      {# Item Attributes #}
+      {% set list_attributes = create_attribute() %}
+      {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item") %}
+      {% if item.below is not empty %}
+        {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item--parent") %}
+      {% endif %}
+      {% if item.in_active_trail == true %}
+        {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item--active-trail") %}
+      {% endif %}
+      {% if item.is_active == true %}
+        {% set list_attributes = list_attributes.addClass(class_prefix ~ "__item--current") %}
+        {% set link_attributes = link_attributes.setAttribute('aria-current', 'true') %}
+      {% endif %}
+
+      {# Skip non-trail items below the first level. #}
+      {% if item.in_active_trail == true or menu_level == 1 or parent.in_active_trail == true %}
+        <li{{ list_attributes }}>
+          <a{{ link_attributes }}>
+            {{ item.title }}
+            {% if item.unpublished %}
+              <div class="unpublished-indicator">{{ "Unpublished Page"|t }}</div>
+            {% endif %}
+          </a>
+          {% if item.below %}
+            {{ menus.secondary_nav_menu(item.below, menu_level + 1, class_prefix, item) }}
           {% endif %}
-        </a>
-        {% if item.below %}
-          {{ menus.secondary_nav_menu(item.below, menu_level + 1, class_prefix, item) }}
-        {% endif %}
-      </li>
-    {% endif %}
-  {% endfor %}
-  </ul>
+        </li>
+      {% endif %}
+    {% endfor %}
+    </ul>
+  {% endif %}
 {% endmacro %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Prevent empty `<ul>` elements in secondary nav

# Need Review By (Date)
- 7/8

# Urgency
- High

# Steps to Test
1. Checkout this branch
2. create a page and place it under a parent menu item
3. create another page and place it under the page previously created
4. create another page and place it under the same parent menu item as the first page above.
5. View the markup of the secondary navigation and ensure there are no empty `<ul>` tags

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
