### PR TITLE
Add aria attributes for field labels

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -109,6 +109,14 @@ function stanford_basic_preprocess_field(&$variables, $hook) {
     }
   }
 
+  if (!$variables['label_hidden']) {
+    $variables['title_attributes']['class'][] = 'label';
+    $hash = "{$variables['entity_type']}-{$variables['bundle']}-{$variables['field_name']}";
+    $id = Html::getUniqueId('field--' . substr(md5($hash), 0, 5));
+    $variables['title_attributes']['id'] = $id;
+    $variables['attributes']['role'] = 'group';
+    $variables['attributes']['aria-labelledby'] = $id;
+  }
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add a couple aria attributes to fields that display their labels.

# Need Review By (Date)
- 8/20

# Urgency
- low

# Steps to Test
1. checkout this branch
2. clear caches
3. view an piece of content that displays the label on it's fields (like people)
4. review the markup on the fields with it's aria attributes.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
