### PR TITLE
preg_replace of null is deprecated in php 8, use strings

### DIFF
--- a/stanford_basic.theme
+++ b/stanford_basic.theme
@@ -138,8 +138,8 @@ function stanford_basic_preprocess_views_view(&$variables) {
  * @return string
  *   Cleaned string.
  */
-function _stanford_basic_change_characters($string) {
-  return preg_replace("/[^a-zA-Z\d\s]/", '-', $string);
+function _stanford_basic_change_characters($string = '') {
+  return preg_replace("/[^a-zA-Z\d\s]/", '-', $string ?? '');
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Make sure `preg_replace` is acting on a string instead of `null`

# Need Review By (Date)
- 

# Urgency
- 

# Steps to Test

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
